### PR TITLE
Building on FreeBSD (DO NOT MERGE)

### DIFF
--- a/src/gl.cc
+++ b/src/gl.cc
@@ -9,6 +9,7 @@
  * See the file LICENSE for the full license.
  */
 
+#include <string>
 #include "gl.h"
 
 namespace gl {

--- a/src/pty.cc
+++ b/src/pty.cc
@@ -143,7 +143,6 @@ namespace zutty {
          struct termios term;
          if (tcgetattr (STDIN_FILENO, &term) < 0)
             SYS_ERROR ("tcgetattr");
-         term.c_iflag |= IUTF8;
          if (tcsetattr (STDIN_FILENO, TCSANOW, &term) < 0)
             SYS_ERROR ("tcsetattr");
       }

--- a/wscript
+++ b/wscript
@@ -42,6 +42,7 @@ def configure(cfg):
         '-Wno-unused-parameter',
         '-Wsign-compare',
         '-std=c++14',
+        '-I/usr/local/include',
         '-g', '-ggdb',
         '-O2', '-march=native',
         '-fno-omit-frame-pointer',
@@ -52,7 +53,7 @@ def configure(cfg):
         cfg.env.append_value('CXXFLAGS', ['-DDEBUG'])
 
     if cfg.options.werror:
-        cfg.env.append_value('CXXFLAGS', ['-Werror'])
+        pass
 
     default_libpath = cmd ("echo /usr/lib/$(gcc -dumpmachine)")
     cfg.env.LIB_EGL     = ['EGL']


### PR DESCRIPTION
Hi!  I heard about zutty today and wanted to try it.  I use FreeBSD. (and inherently use Clang)
```
$ uname -a
FreeBSD nyann.tanasinn.mochi 12.2-RELEASE-p1 FreeBSD 12.2-RELEASE-p1 GENERIC  amd64
$ freebsd-version -kru
12.2-RELEASE-p1
12.2-RELEASE-p1
12.2-RELEASE-p2
```

I found zutty doesn't compile on FreeBSD.  But with a few changes, it does.

You _won't_ want to accept this pull request, as it's merely to show what steps I needed to take to get zutty to compile.  You may, however, want to take the diff for `src/gl.cc`.  I added an `#include <string>` because otherwise C++'s `to_string` wouldn't work.
Please read all three commit descriptions.
I also think -Wpedantic could be added to the list of compiler flags.

Also, even with this pull request, when run, zutty only shows on screen for a brief moment before dumping core.
```
$ ./zutty -verbose -fontpath /usr/local/share/fonts 
Zutty 0.7
Copyright (C) 2020 Tom Szilagyi

This program comes with ABSOLUTELY NO WARRANTY.
Zutty is free software, and you are welcome to redistribute it
under the terms and conditions of the GNU GPL v3 (or later).

T [main.cc:354] Shell subprocess started, pid: 3838
T [fontpack.cc:181] Fontpack: fontpath=/usr/local/share/fonts; fontname=9x18
T [fontpack.cc: 42] Bold: /usr/local/share/fonts/misc/9x18B.pcf.gz
T [fontpack.cc: 42] Regular: /usr/local/share/fonts/misc/9x18.pcf.gz
I [font.cc: 54] Loading /usr/local/share/fonts/misc/9x18.pcf.gz as primary
T [font.cc: 60] Family: Misc Fixed; Style: Regular; Faces: 1; Glyphs: 4767
T [font.cc:162] Available sizes: 9x18
T [font.cc:165] Configured size: 16; Best matching fixed size: 9x18
I [font.cc:198] Glyph size 9x18
T [font.cc: 95] Atlas texture geometry: 98x49 glyphs of 9x18 each, yielding pixel size 882x882.
T [font.cc: 99] Atlas holds space for 4802 glyphs, 4768 will be used, empty: 34 (0.708038%)
T [font.cc:106] Allocating 777924 bytes for atlas buffer
I [font.cc: 54] Loading /usr/local/share/fonts/misc/9x18B.pcf.gz as overlay
T [font.cc: 60] Family: Misc Fixed; Style: Bold; Faces: 1; Glyphs: 763
T [font.cc:162] Available sizes: 9x18
T [font.cc:165] Configured size: 16; Best matching fixed size: 9x18
I [font.cc:198] Glyph size 9x18
I [main.cc:123] Window ID: 50331650 / 0x3000002
T [selmgr.cc: 32] SelectionManager: chunkSize=1048575
T [vterm.icc:1597] csi_SGR [0]  p(0,0)  d(24,80)  mgn[0,24)  hmgn:0 [0,80)  cur=0  head=0
T [main.cc:897] x11_fd = 3
T [main.cc:898] pty_fd = 4
T [selmgr.cc: 69] onPropertyNotify on '_NET_WM_PID' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_CLIENT_MACHINE' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_NORMAL_HINTS' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_NAME' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_ICON_NAME' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_NORMAL_HINTS' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_PROTOCOLS' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on '_FLUXBOX_GROUP_LEFT' (NewValue)
T [main.cc:829] ReparentNotify
T [main.cc:836] MapNotify
T [selmgr.cc: 69] onPropertyNotify on '_NET_WM_DESKTOP' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on '_NET_FRAME_EXTENTS' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on '_NET_WM_ALLOWED_ACTIONS' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on 'WM_STATE' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on '_NET_WM_DESKTOP' (NewValue)
T [selmgr.cc: 69] onPropertyNotify on '_NET_FRAME_EXTENTS' (NewValue)
T [vterm.icc:681] showCursor [0]        p(0,0)  d(24,80)  mgn[0,24)  hmgn:0 [0,80)  cur=0  head=0
T [charvdev.cc:541] compute program: uniform glyphPixels=6 sizeChars=11 cursorColor=2 cursorPos=3 cursorStyle=4 selectRect=9 selectRectMode=10 selectDamage=8 deltaFrame=5
T [charvdev.cc:563] draw program: attrib pos=0 vertexTexCoord=1 uniform viewPixels=1
I [charvdev.cc:389] Resize to 724 x 436 pixels, 80 x 24 chars
$ 
```

After you read this PR, please close it.

For context: I'm a C programmer, not a C++ programmer (and not yet a Python programmer, though I should become one)
(also, I apologise for the state of my github profile: I usually don't have one, and having this one is temporary)