### PR TITLE
Use PATH based lookup for default shell

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -44,7 +44,7 @@ namespace zutty {
       {"help",      XrmoptionNoArg,    "true",  "false",     "Print usage information"},
       {"rv",        XrmoptionNoArg,    "true",  "false",     "Reverse video"},
       {"selection", XrmoptionSepArg,   nullptr, "primary",   "Selection target"},
-      {"shell",     XrmoptionSepArg,   nullptr, "/bin/bash", "Shell program to run"},
+      {"shell",     XrmoptionSepArg,   nullptr, "bash",      "Shell program to run"},
       {"title",     XrmoptionSepArg,   nullptr, "Zutty",     "Window title"},
       {"quiet",     XrmoptionNoArg,    "true",  "false",     "Silence logging output"},
       {"verbose",   XrmoptionNoArg,    "true",  "false",     "Output info messages"},


### PR DESCRIPTION
On some systems bash isn't at /bin/bash (NixOS, FreeBSD, mac).

I know I can just pass `-e bash` to the cmdline args but this just seems like a nicer default, especially considering there really isn't very good feedback from not finding /bin/bash.