### PR TITLE
Steps to compile and run Zutty on FreeBSD (do not merge)

### DIFF
--- a/src/pty.cc
+++ b/src/pty.cc
@@ -136,7 +136,6 @@ namespace zutty {
          struct termios term;
          if (tcgetattr (STDIN_FILENO, &term) < 0)
             SYS_ERROR ("tcgetattr");
-         term.c_iflag |= IUTF8;
          if (tcsetattr (STDIN_FILENO, TCSANOW, &term) < 0)
             SYS_ERROR ("tcsetattr");
       }

--- a/wscript
+++ b/wscript
@@ -44,6 +44,7 @@ def configure(cfg):
         '-fno-omit-frame-pointer',
         '-fsigned-char',
         '-Wall',
+        '-I/usr/local/include',
         '-Wextra',
         '-Wsign-compare',
         '-Wno-unused-parameter'
@@ -58,8 +59,7 @@ def configure(cfg):
                              ])
     else:
         cfg.env.append_value('CXXFLAGS',
-                             ['-Werror',
-                              '-O3', '-march=native', '-mtune=native',
+                             ['-O3', '-march=native', '-mtune=native',
                               '-flto'
                              ])
         cfg.env.append_value('LINKFLAGS', ['-flto'])


### PR DESCRIPTION
These show the actual steps I take to get Zutty to compile on FreeBSD.  This pull request serves only to document this diff which I'll reference in a future issue on Zutty and FreeBSD. (do not merge)

As for `wscript`:
Add the `-I/usr/local/include` flag so `EGL/egl.h` and `GLES3/gl31.h` can be found.  I'm not sure how to make waf or wscript check for this: I believe GNU's autotools do successfully check `/usr/local/` for includes and libs if I remember right.  There may be an equivalent.
Remove the `-Werror` flag so the warning for including `sys/termios.h` instead of `termios.h` isn't turned into an error.

As for `src/pty.cc`:
Remove the undefined `IUTF8`, which doesn't exist on FreeBSD.

When I run Zutty, I do it like this:
```
$ ./zutty -fontpath /usr/local/share/fonts
```
I start Zutty from `uxterm` rather than `xterm`.