### PR TITLE
Make testbase.sh usage of ps work on FreeBSD

### DIFF
--- a/test/testbase.sh
+++ b/test/testbase.sh
@@ -137,7 +137,7 @@ fi
 # wait until window opens and grab its X window id
 WID=''
 while true ; do
-    if [[ -z "$(ps --no-header -o pid ${PID})" ]] ; then
+    if [[ -z "$(ps -o pid= ${PID})" ]] ; then
         echo "UUT process ${PID} gone, aborting."
         exit 1
     fi


### PR DESCRIPTION
This fixes the usage of ps here.  Not only does this make it work on FreeBSD, but it also makes the usage POSIX-compliant:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html

Please confirm that the behavior is not changed on GNU/Linux before merging. (I don't have any easy way to test on GNU/Linux)
Also, more patches may come in as I come across more things which prevent me from running the test scripts.