### PR TITLE
Add missing include to fix GCC 11 build

### DIFF
--- a/src/font.cc
+++ b/src/font.cc
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
When building with g++ 11.1.0:

```
../src/font.cc: In member function ‘void zutty::Font::loadFixed(FT_FaceRec_* const&)’:
../src/font.cc:146:33: error: ‘numeric_limits’ is not a member of ‘std’
  146 |       int bestHeightDiff = std::numeric_limits<int>::max ();
      |                                 ^~~~~~~~~~~~~~
../src/font.cc:146:48: error: expected primary-expression before ‘int’
  146 |       int bestHeightDiff = std::numeric_limits<int>::max ();
```