### PR TITLE
Add check for --version and --help that will exit before initializing anything

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1194,6 +1194,17 @@ main (int argc, char* argv[])
    char* imvalret;
    int i;
 
+   if (argc > 1 && strcmp (argv [1], "--help") == 0)
+   {
+       opts.printUsage ();
+       exit(0);
+   }
+   if (argc > 1 && strcmp (argv [1], "--version") == 0)
+   {
+       opts.printVersion ();
+       exit(0);
+   }
+
    {
       const char* loc;
       bool warn = false;


### PR DESCRIPTION
* Add a check for `--help` that will show the usage information and then exit, without initializing anything.
* Add a check for `--version` that will show version information and then exit, without initializing anything.

I see that Zutty also supports `-help`. However, `--help` and `--version` are almost universally available on the command line in Linux, and it's a nice service towards users that they can expect those flags to be present, also for Zutty.